### PR TITLE
Expose onSubmitted

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,6 +51,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 length: values.length,
                 delimeters: [',', ' '],
                 hasAddButton: true,
+                resetTextOnSubmitted: true,
                 onSubmitted: (outstandingValue) {
                   setState(() {
                     values.add(outstandingValue);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,11 @@ class _MyHomePageState extends State<MyHomePage> {
                 length: values.length,
                 delimeters: [',', ' '],
                 hasAddButton: true,
-                textInputActionCreatesTag: true,
+                onSubmitted: (outstandingValue) {
+                  setState(() {
+                    values.add(outstandingValue);
+                  });
+                },
                 inputDecoration: const InputDecoration(
                   border: InputBorder.none,
                   hintText: 'Hint Text...',

--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -28,6 +28,7 @@ class TagEditor extends StatefulWidget {
     this.autocorrect = false,
     this.enableSuggestions = true,
     this.maxLines = 1,
+    this.resetTextOnSubmitted = false,
     this.onSubmitted,
     this.keyboardAppearance,
   }) : super(key: key);
@@ -40,8 +41,16 @@ class TagEditor extends StatefulWidget {
   final IconData icon;
   final bool enabled;
 
+  /// Reset the TextField when `onSubmitted` is called
+  /// this is default to `false` because when the form is submitted
+  /// usually the outstanding value is just used, but this option is here
+  /// in case you want to reset it for any reasons (like convering the
+  /// outstanding value to tag)
+  final bool resetTextOnSubmitted;
+
   /// Called when the user are done editing the text in the [TextField]
   /// Use this to get the outstanding text that aren't converted to tag yet
+  /// If no text is entered when this is called an empty string will be passed
   final ValueChanged<String> onSubmitted;
 
   /// [TextField]'s Props
@@ -113,6 +122,13 @@ class _TagsEditorState extends State<TagEditor> {
           _onTagChanged(targetString);
         }
       }
+    }
+  }
+
+  void _onSubmitted(String string) {
+    widget.onSubmitted(string);
+    if (widget.resetTextOnSubmitted) {
+      _textFieldController.text = '';
     }
   }
 
@@ -194,7 +210,7 @@ class _TagsEditorState extends State<TagEditor> {
                   maxLines: widget.maxLines,
                   decoration: decoration,
                   onChanged: _onTextFieldChange,
-                  onSubmitted: widget.onSubmitted,
+                  onSubmitted: _onSubmitted,
                 ),
               )
             ],

--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -96,7 +96,7 @@ class _TagsEditorState extends State<TagEditor> {
     }
   }
 
-  void _onTextFieldChange(String string, {bool submitted = false}) {
+  void _onTextFieldChange(String string) {
     // This function looks ugly fix this
     final previousText = _previousText;
     _previousText = string;
@@ -104,10 +104,10 @@ class _TagsEditorState extends State<TagEditor> {
       return;
     }
 
-    if (string.length > previousText.length || submitted) {
+    if (string.length > previousText.length) {
       // Add case
       final newChar = string[string.length - 1];
-      if (widget.delimeters.contains(newChar) || submitted) {
+      if (widget.delimeters.contains(newChar)) {
         final targetString = string.substring(0, string.length - 1);
         if (targetString.isNotEmpty) {
           _onTagChanged(targetString);

--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -28,7 +28,7 @@ class TagEditor extends StatefulWidget {
     this.autocorrect = false,
     this.enableSuggestions = true,
     this.maxLines = 1,
-    this.textInputActionCreatesTag = false,
+    this.onSubmitted,
     this.keyboardAppearance,
   }) : super(key: key);
 
@@ -40,7 +40,12 @@ class TagEditor extends StatefulWidget {
   final IconData icon;
   final bool enabled;
 
+  /// Called when the user are done editing the text in the [TextField]
+  /// Use this to get the outstanding text that aren't converted to tag yet
+  final ValueChanged<String> onSubmitted;
+
   /// [TextField]'s Props
+  /// Please refer to [TextField] documentation
   final InputDecoration inputDecoration;
   final TextInputType keyboardType;
   final TextInputAction textInputAction;
@@ -52,7 +57,6 @@ class TagEditor extends StatefulWidget {
   final bool enableSuggestions;
   final int maxLines;
   final bool readOnly;
-  final bool textInputActionCreatesTag;
   final Brightness keyboardAppearance;
 
   @override
@@ -189,14 +193,8 @@ class _TagsEditorState extends State<TagEditor> {
                   enableSuggestions: widget.enableSuggestions,
                   maxLines: widget.maxLines,
                   decoration: decoration,
-                  onChanged: (text) {
-                    _onTextFieldChange(text);
-                  },
-                  onSubmitted: (text) {
-                    if (widget.textInputActionCreatesTag) {
-                      _onTextFieldChange(text, submitted: true);
-                    }
-                  },
+                  onChanged: _onTextFieldChange,
+                  onSubmitted: widget.onSubmitted,
                 ),
               )
             ],


### PR DESCRIPTION
https://github.com/panuavakul/material_tag_editor/issues/8 https://github.com/panuavakul/material_tag_editor/issues/5

Exposing onSubmitted that will pass the outstanding TextField's value so that people can do what they want with it (like adding it to the state and submit it somewhere)