### PR TITLE
Expose minTextViewWidth and tagSpacing

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,11 +60,12 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+          child: ListView(
             children: <Widget>[
               TagEditor(
                 length: _values.length,
+                tagSpacing: 24,
+                minTextFieldWidth: 80,
                 controller: _textEditingController,
                 focusNode: _focusNode,
                 delimiters: [',', ' '],

--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -8,6 +8,8 @@ import './tag_layout.dart';
 class TagEditor extends StatefulWidget {
   const TagEditor({
     required this.length,
+    this.minTextFieldWidth = 160.0,
+    this.tagSpacing = 4.0,
     required this.tagBuilder,
     required this.onTagChanged,
     Key? key,
@@ -37,6 +39,12 @@ class TagEditor extends StatefulWidget {
 
   /// The number of tags currently shown.
   final int length;
+
+  /// The minimum width that the `TextField` should take
+  final double minTextFieldWidth;
+
+  /// The spacing between each tag
+  final double tagSpacing;
 
   /// Builder for building the tags, this usually use Flutter's Material `Chip`.
   final Widget Function(BuildContext, int) tagBuilder;
@@ -207,7 +215,11 @@ class _TagsEditorState extends State<TagEditor> {
 
     final tagEditorArea = Container(
       child: TagLayout(
-        delegate: TagEditorLayoutDelegate(length: widget.length),
+        delegate: TagEditorLayoutDelegate(
+          length: widget.length,
+          minTextFieldWidth: widget.minTextFieldWidth,
+          spacing: widget.tagSpacing,
+        ),
         children: List<Widget>.generate(
               widget.length,
               (index) => LayoutId(

--- a/lib/tag_editor_layout_delegate.dart
+++ b/lib/tag_editor_layout_delegate.dart
@@ -5,15 +5,15 @@ import 'package:flutter/rendering.dart';
 class TagEditorLayoutDelegate extends MultiChildLayoutDelegate {
   TagEditorLayoutDelegate({
     required this.length,
-    this.minTextWidth = 160,
-    this.spacing = 4.0,
+    required this.minTextFieldWidth,
+    required this.spacing,
   });
 
   static const tagId = 'tag_';
   static const textFieldId = 'text_field';
 
   final int length;
-  final double minTextWidth;
+  final double minTextFieldWidth;
   final double spacing;
 
   /// This is used for
@@ -23,7 +23,7 @@ class TagEditorLayoutDelegate extends MultiChildLayoutDelegate {
     return '$tagId$id';
   }
 
-  static bool isOverflow({
+  static bool _isOverflow({
     required double childWidth,
     required double parentWidth,
     required List<Size> tagSizes,
@@ -60,7 +60,7 @@ class TagEditorLayoutDelegate extends MultiChildLayoutDelegate {
         );
 
         //* Check if overflowing
-        if (isOverflow(
+        if (_isOverflow(
           childWidth: childSize.width,
           parentWidth: size.width,
           tagSizes: tagSizes,
@@ -90,10 +90,10 @@ class TagEditorLayoutDelegate extends MultiChildLayoutDelegate {
       });
       final spacingWidth = spacing * max(tagSizes.length - 1, 0);
       final leftOverWidth = size.width - currentRowWidth - spacingWidth;
-      final textWidth = max(leftOverWidth, minTextWidth);
+      final textWidth = max(leftOverWidth, minTextFieldWidth);
       //* Check if Textbox is overflowing
       //* Check if overflowing
-      if (isOverflow(
+      if (_isOverflow(
         childWidth: textWidth,
         parentWidth: size.width,
         tagSizes: tagSizes,


### PR DESCRIPTION
I totally forgot that the minTextFieldWidth and tagSpacing was fixed so just exposing it for easy customization. .https://github.com/panuavakul/material_tag_editor/compare/feature/expose_min_width_and_spacing?expand=1#diff-857ef96b39b6ab14ff311e56d629280b54d4c42aec9f44cbfdfa188ef86e711fL8