### PR TITLE
Don't allow delimiter input in the TextField

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,8 +64,6 @@ class _MyHomePageState extends State<MyHomePage> {
             children: <Widget>[
               TagEditor(
                 length: _values.length,
-                tagSpacing: 24,
-                minTextFieldWidth: 80,
                 controller: _textEditingController,
                 focusNode: _focusNode,
                 delimiters: [',', ' '],

--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -135,11 +135,20 @@ class _TagsEditorState extends State<TagEditor> {
     }
   }
 
+  /// This function is still ugly, have to fix this later
   void _onTextFieldChange(String string) {
-    // This function looks ugly fix this
     final previousText = _previousText;
     _previousText = string;
+
     if (string.isEmpty || widget.delimiters.isEmpty) {
+      return;
+    }
+
+    // Do not allow the entry of the delimters, this does not account for when
+    // the text is set with `TextEditingController` the behaviour of TextEditingContoller
+    // should be controller by the developer themselves
+    if (string.length == 1 && widget.delimiters.contains(string)) {
+      _resetTextField();
       return;
     }
 


### PR DESCRIPTION
Since we only check when the TextField isn't empty, there were some cases if the delimiter were enter twice in a row like `,,` or `  ` then onTagChanged will be called resulting with empty tag being created.

I think it's better if we just do not allow the delimiters to be inputted in the TextField.